### PR TITLE
fix(utils): correct time

### DIFF
--- a/utilities/time.ts
+++ b/utilities/time.ts
@@ -49,6 +49,6 @@ export const duration = {
     return BigNumber.from(val).mul(this.days("7"))
   },
   years: function (val) {
-    return BigNumber.from(val).mul(this.days("365"))
+    return BigNumber.from(val).mul(this.days("365.2425"))
   },
 }


### PR DESCRIPTION
365 provides an error per years of 0.2422 or over 100 years 24.22 days. 
365.2425 provides an error per years of -0.0003	 or over 100 years 0.03 days.

Alternative fix would be to use unix timestamps and provide a human output from that. 
unix epoch timestamps do not take into account leapyears.